### PR TITLE
Remove redundant sort

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -201,7 +201,7 @@ function prep_sparse!(A,n,m,i,nzA,sigmaA,qA,κ)
         nzA[j,i] = nnz(A[i,j+1])
     end
     sigmaA[:,i] = sortperm(nzA[:,i], rev = true)
-    sisi = sort(nzA[sigmaA[:,i],i], rev = true)
+    sisi = nzA[sigmaA[:,i],i]
     # @show sisi
 
     qA[1,i] = n


### PR DESCRIPTION
As `sigmaA[:,i]`, is the result of `sortperm`, `nzA[sigmaA[:,i],i]` should already be sorted so no need to sort again