### PR TITLE
Specialized dot product

### DIFF
--- a/src/Solvers.jl
+++ b/src/Solvers.jl
@@ -219,7 +219,6 @@ function load(model, options::Dict; T = Float64)
         datasparsity,
         MyModel(model.A,
             model.AA,
-            model.myA,
             model.B,
             model.C,
             model.nzA,

--- a/src/makeBBBB.jl
+++ b/src/makeBBBB.jl
@@ -21,22 +21,48 @@ end
 
 #########################
 
-function makeBBBBs(n,nlmi,A,AA,myA,W,to,qA,sigmaA)
+function makeBBBBs(n,nlmi,A,AA,W,to,qA,sigmaA)
     BBBB = zeros(Float64, n, n)
     @inbounds for ilmi = 1:nlmi
         Wilmi = W[ilmi]
         AAilmi = AA[ilmi]
         Ailmi = A[ilmi,:]
         @timeit to "BBBBs" begin
-        BBBB += makeBBBBsi(ilmi,Ailmi,AAilmi,myA,Wilmi,n,to,qA,sigmaA)
+        BBBB += makeBBBBsi(ilmi,Ailmi,AAilmi,Wilmi,n,to,qA,sigmaA)
         end
     end
 
     return BBBB
 end
 
+# Computes `⟨A * W, W * B⟩` for symmetric sparse matrices `A` and `B`
+function _dot(A::SparseMatrixCSC, B::SparseMatrixCSC, W::Matrix)
+    @assert LinearAlgebra.checksquare(W) == LinearAlgebra.checksquare(A) == LinearAlgebra.checksquare(B)
+    result = zero(eltype(A))
+    for i in axes(A, 2)
+        nzA = nzrange(A, i)
+        if !isempty(nzA)
+            for j in axes(B, 2)
+                nzB = nzrange(B, j)
+                if !isempty(nzB)
+                    AW = zero(result)
+                    for k in nzA
+                        AW += nonzeros(A)[k] * W[rowvals(A)[k], j]
+                    end
+                    WB = zero(result)
+                    for k in nzB
+                        WB += W[i, rowvals(B)[k]] * nonzeros(B)[k]
+                    end
+                    result += AW * WB
+                end
+            end
+        end
+    end
+    return result
+end
+
 #####
-function makeBBBBsi(ilmi,Ailmi,AAilmi,myA,Wilmi::Matrix{T},n,to,qA,sigmaA) where {T}
+function makeBBBBsi(ilmi,Ailmi,AAilmi,Wilmi::Matrix{T},n,to,qA,sigmaA) where {T}
     BBBB = zeros(T, n, n)
     tmp1 = Matrix{T}(undef,size(Wilmi, 2), size(Ailmi[1], 1))
     # tmp = Matrix{Float64}(undef,size(Wilmi, 1), size(Wilmi, 1))
@@ -81,24 +107,22 @@ function makeBBBBsi(ilmi,Ailmi,AAilmi,myA,Wilmi::Matrix{T},n,to,qA,sigmaA) where
                 mul!(tmp1,Ailmi[i+1],Wilmi)
                 @inbounds for jj = ii:n
                     j = sigmaA[jj,ilmi]
-                    if ~isempty(myA[ilmi1+j].iind)
-                        myAjjj = myA[ilmi1+j]
-                        iii_j = myAjjj.iind
-                        jjj_j = myAjjj.jind
-                        vvv_j = myAjjj.nzval
+                    Ajjj = Ailmi[j+1]
+                    if !iszero(nnz(Ajjj))
                         ttt = 0.0
                         # @timeit to "BBBBtwo_i" begin
-                        @inbounds for iAj in eachindex(iii_j)
+                        @inbounds for jjjjAj in axes(Ajjj, 2)
+                            for k in nzrange(Ajjj, jjjjAj)
                             # @timeit to "BBBBtwo_ii_A" begin
-                            iiijAj = iii_j[iAj]
-                            jjjjAj = jjj_j[iAj]
+                                iiijAj = rowvals(Ajjj)[k]
                             # end
                             # vvvj = -vvv_j[iAj]    
                             # @timeit to "BBBBtwo_i_B" begin
-                            ttt1 = dot(tmp1[:,iiijAj],Wilmi[:,jjjjAj])
+                                ttt1 = dot(tmp1[:,iiijAj],Wilmi[:,jjjjAj])
                             # end
                             # @timeit to "BBBBtwo_i_C" begin
-                            ttt -= ttt1 * vvv_j[iAj]
+                                ttt += ttt1 * nonzeros(Ajjj)[k]
+                            end
                             # end
                         end
                         # end
@@ -115,31 +139,24 @@ function makeBBBBsi(ilmi,Ailmi,AAilmi,myA,Wilmi::Matrix{T},n,to,qA,sigmaA) where
                 # @show "three"
                 # @show ilmi
                 # @show ii
-                if ~isempty(myA[ilmi1+i].iind)
-                    myAiii = myA[ilmi1+i]
-                    if size(myAiii.iind,1) > 1
+                if !iszero(nnz(Ailmi[i+1]))
+                    if nnz(Ailmi[i+1]) > 1
                         # @timeit to "BBBBthree>1" begin
-                        iii_is = union(myAiii.iind)
                         # @show iii_i,myAiii.jind
                         # iii_is = iii_i[1:Int64(sqrt(length(iii_i)))]
                         # jjj_i = myAiii.jind
                         # vvv_i = myAiii.nzval
-                        mya1 = Ailmi[i+1][iii_is,iii_is]
                         @inbounds for jj = ii:n
                             j = sigmaA[jj,ilmi]
-                            if ~isempty(myA[ilmi1+j].iind)
+                            if !iszero(nnz(Ailmi[j+1]))
                                 # @timeit to "BBBBthree_1>1" begin
-                                myAjjj = myA[ilmi1+j]
-                                iii_js = union(myAjjj.iind)
                                 # iii_js = iii_j[1:Int64(sqrt(length(iii_j)))]
                                 # jjj_j = myAjjj.jind
                                 # vvv_j = myAjjj.nzval
                                 # ttt = 0.0
-                                myw = Wilmi[iii_is,iii_js]                            
-                                mya2 = Ailmi[j+1][iii_js,iii_js]
                                 # end
                                 # @timeit to "BBBBthree_2>1" begin
-                                ttt = transpose(vec(transpose(mya1 * myw))) * vec(mya2 * transpose(myw))
+                                ttt = _dot(Ailmi[i+1], Ailmi[j+1], Wilmi)
                                 # end
                                 # @inbounds for iAj in eachindex(iii_j)
                                 #     ttt1 = 0.0
@@ -167,16 +184,18 @@ function makeBBBBsi(ilmi,Ailmi,AAilmi,myA,Wilmi::Matrix{T},n,to,qA,sigmaA) where
                         end   
                     else
                         @timeit to "BBBBthree=1" begin
-                        iiiiAi = myAiii.iind[1]
-                        jjjiAi = myAiii.jind[1]
-                        vvvi = myAiii.nzval[1]
+                        # A is symmetric
+                        iiiiAi = jjjiAi = only(rowvals(Ailmi[i+1]))
+                        vvvi = only(nonzeros(Ailmi[i+1]))
                         @inbounds for jj = ii:n
                             j = sigmaA[jj,ilmi]
-                            if ~isempty(myA[ilmi1+j].iind)
-                                myAjjj = myA[ilmi1+j]
-                                iiijAj = myAjjj.iind[1]
-                                jjjjAj = myAjjj.jind[1]
-                                vvvj = myAjjj.nzval[1]
+                            Ajjj = Ailmi[j+1]
+                            # As we sort the matrices in decreasing `nnz` order,
+                            # the rest of matrices is either zero or have only
+                            # one entry
+                            if !iszero(nnz(Ajjj))
+                                iiijAj = jjjjAj = only(rowvals(Ajjj))
+                                vvvj = only(nonzeros(Ajjj))
                                 ttt = vvvi * Wilmi[iiiiAi,iiijAj] * Wilmi[jjjiAi,jjjjAj] * vvvj
                                 if i >= j
                                     BBBB[i,j] = ttt

--- a/src/makeBBBB.jl
+++ b/src/makeBBBB.jl
@@ -38,8 +38,10 @@ end
 # Computes `⟨A * W, W * B⟩` for symmetric sparse matrices `A` and `B`
 function _dot(A::SparseMatrixCSC, B::SparseMatrixCSC, W::Matrix)
     @assert LinearAlgebra.checksquare(W) == LinearAlgebra.checksquare(A) == LinearAlgebra.checksquare(B)
+    # After these asserts, we know that `A`, `B` and `W` are square and
+    # have the same sizes so we can safely use `@inbounds`
     result = zero(eltype(A))
-    for i in axes(A, 2)
+    @inbounds for i in axes(A, 2)
         nzA = nzrange(A, i)
         if !isempty(nzA)
             for j in axes(B, 2)

--- a/src/model.jl
+++ b/src/model.jl
@@ -41,7 +41,6 @@ The fields of the `struct` as related to the arrays of the above formulation as 
 mutable struct MyModel
     A::Matrix{Any}
     AA::Vector{SparseArrays.SparseMatrixCSC{Float64}}
-    myA::Vector{SpMa{Float64}}
     B::Vector{SparseArrays.SparseMatrixCSC{Float64}}
     C::Vector{SparseArrays.SparseMatrixCSC{Float64}}
     nzA::Matrix{Int64}
@@ -59,7 +58,6 @@ mutable struct MyModel
     function MyModel(
         A::Matrix{Any},
         AA::Vector{SparseArrays.SparseMatrixCSC{Float64}},
-        myA::Vector{SpMa{Float64}},
         B::Vector{SparseArrays.SparseMatrixCSC{Float64}},
         C::Vector{SparseArrays.SparseMatrixCSC{Float64}},
         nzA::Matrix{Int64},
@@ -78,7 +76,6 @@ mutable struct MyModel
         model = new()
         model.A = A
         model.AA = AA
-        model.myA = myA
         model.B = B
         model.C = C
         model.nzA = nzA
@@ -132,7 +129,6 @@ function _prepare_A(A, datarank, κ)
     nlmi = size(A, 1)
     n = size(A, 2) - 1
     AA = SparseMatrixCSC{Float64}[]
-    myA = SpMa{Float64}[]
     B = SparseMatrixCSC{Float64}[]
     C = SparseMatrixCSC{Float64}[]
     nzA = zeros(Int64,n,nlmi)
@@ -145,7 +141,7 @@ function _prepare_A(A, datarank, κ)
 
         Ai = A[i,:]
         m = size(Ai,1)
-        AAA = prep_AA!(myA,Ai,n)
+        AAA = prep_AA!(Ai,n)
         push!(AA, copy(AAA'))
 
         if datarank == -1
@@ -157,7 +153,7 @@ function _prepare_A(A, datarank, κ)
 
     end
 
-    return AA, myA, B, C, nzA, sigmaA, qA
+    return AA, B, C, nzA, sigmaA, qA
 end
 
 
@@ -207,7 +203,7 @@ function prep_B(A,n,i)
     return Btmp
 end
 
-function prep_AA!(myA,Ai,n)
+function prep_AA!(Ai,n)
 
     @inbounds Threads.@threads for j = 1:n
         if isempty(Ai[j+1])
@@ -219,9 +215,7 @@ function prep_AA!(myA,Ai,n)
     
     nnz = 0
     @inbounds for j = 1:n
-        ii,jj,vv = findnz(-(Ai[j+1]))
-        push!(myA,SpMa(Int64(length(ii)),ii,jj,float(vv)))
-        nnz += length(ii)
+        nnz += SparseArrays.nnz(Ai[j+1])
     end
 
     iii = zeros(Int64, nnz)

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,16 +1,9 @@
-export prepare_model_data, MyModel, SpMa
+export prepare_model_data, MyModel
 
 using SparseArrays
 using Printf
 using TimerOutputs
 using LinearAlgebra
-
-struct SpMa{Tv,Ti<:Integer}
-    n::Int64
-    iind::Vector{Ti}
-    jind::Vector{Ti}
-    nzval::Vector{Tv}
-end
 
 """
     MyModel

--- a/src/predictor_corrector.jl
+++ b/src/predictor_corrector.jl
@@ -28,7 +28,7 @@ function predictor(solver::MySolver{T},halpha::Halpha) where {T}
             # if 1 == 0
                 BBBB = makeBBBB_rank1(solver.model.n, solver.model.nlmi, solver.model.B, solver.G, solver.to)
             else
-                BBBB = makeBBBBs(solver.model.n, solver.model.nlmi, solver.model.A, solver.model.AA, solver.model.myA, solver.W, solver.to, solver.model.qA, solver.model.sigmaA)
+                BBBB = makeBBBBs(solver.model.n, solver.model.nlmi, solver.model.A, solver.model.AA, solver.W, solver.to, solver.model.qA, solver.model.sigmaA)
             end
         else
             BBBB = zeros(T, solver.model.n, solver.model.n)


### PR DESCRIPTION
Allocating the submatrices and the result of their product was taking a lot of time.
By writing a custom `_dot` function that is allocation-free, we gain a lot in term of perf and allocations and we don't need `myA` anymore.
The result of `BenchmarkTools.@benchmark optimize!(model)` (using `0` for `verb`) on `examples/solve_sdpa.jl` gives:
Before the PR:
```
BenchmarkTools.Trial: 16 samples with 1 evaluation per sample.
 Range (min … max):  285.593 ms … 365.039 ms  ┊ GC (min … max): 0.00% … 14.98%
 Time  (median):     326.396 ms               ┊ GC (median):    8.39%
 Time  (mean ± σ):   326.294 ms ±  19.043 ms  ┊ GC (mean ± σ):  8.00% ±  4.54%

  ▁     ▁               ▁    ██  █ █ ▁   ▁    ▁    ▁          ▁  
  █▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁██▁▁█▁█▁█▁▁▁█▁▁▁▁█▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█ ▁
  286 ms           Histogram: frequency by time          365 ms <

 Memory estimate: 131.18 MiB, allocs estimate: 2156231.
```
After the PR:
```
BenchmarkTools.Trial: 49 samples with 1 evaluation per sample.
 Range (min … max):   87.494 ms … 146.038 ms  ┊ GC (min … max): 0.00% … 3.78%
 Time  (median):      99.270 ms               ┊ GC (median):    4.47%
 Time  (mean ± σ):   103.155 ms ±  13.001 ms  ┊ GC (mean ± σ):  3.84% ± 3.64%

  ▅    ▂ ▅   ▅█                                                  
  █▁▅▅██▁██▅███▅▅▁█▅▁▁▁▅▁▅█▁▅▅▁▁▅█▁▅▁▅▁▅▁▁▁▁▁▁▁▅▁▁▅▁▁▁▁▁▁▁▁▁▁▁▅ ▁
  87.5 ms          Histogram: frequency by time          146 ms <

 Memory estimate: 37.39 MiB, allocs estimate: 69245.
```
So 96% of reduction in number of allocations, 70% of reduction both in memory allocated and time