### PR TITLE
Use concrete type for SparseMatrixCSC

### DIFF
--- a/TBD/solve_json.jl
+++ b/TBD/solve_json.jl
@@ -43,10 +43,10 @@ for i in eachindex(tmpA)
     BB[tmpA[i][3],tmpA[i][2]+1,tmpA[i][4],tmpA[i][5]] = tmpA[i][1]
 end
 
-A = SparseMatrixCSC{Float64}[]
+A = SparseMatrixCSC{Float64,Int}[]
 # A = Matrix{Any}
 if nlmi == 1  
-    Btmp = SparseMatrixCSC{Float64}[]
+    Btmp = SparseMatrixCSC{Float64,Int}[]
     Ctmp = sparse(BB[1,1,:,:])
     Ctmp = Ctmp + Ctmp' - spdiagm(diag(Ctmp))
     push!(Btmp,Ctmp)
@@ -55,7 +55,7 @@ if nlmi == 1
     end
 else
     for ilmi = 1:nlmi
-        Btmp = SparseMatrixCSC{Float64}[]
+        Btmp = SparseMatrixCSC{Float64,Int}[]
         for j = 1:nvar+1
             push!(Btmp,sparse(BB[ilmi,j,:,:]))
         end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -206,7 +206,7 @@ function MOI.copy_to(dest::Optimizer{T}, src::OptimizerCache) where {T}
     b = dest.max_sense ? b0 : -b0
     # b = max_sense ? -b0 : b0
 
-    AA = Any[sparse(IJV...) for IJV in A]
+    AA = SparseMatrixCSC{Float64,Int}[sparse(IJV...) for IJV in A]
     drank = get(dest.options,"datarank",1)
     κ = get(dest.options,"datasparsity",1)
     model = MyModel(

--- a/src/Solvers.jl
+++ b/src/Solvers.jl
@@ -571,7 +571,7 @@ end
 
 struct MyA{T}
     W::Vector{Matrix{T}}
-    AA::Vector{SparseArrays.SparseMatrixCSC{Float64}}
+    AA::Vector{SparseArrays.SparseMatrixCSC{Float64,Int}}
     nlin::Int64
     C_lin::SparseArrays.SparseMatrixCSC{Float64,Int64}
     X_lin

--- a/src/kron_etc.jl
+++ b/src/kron_etc.jl
@@ -30,7 +30,7 @@ end
 
 
 # How to create a vector of sparse matrices:
-# v = SparseMatrixCSC{Float64}[
+# v = SparseMatrixCSC{Float64,Int}[
 # a=sparse([3 0;0 5])
 # push!(v,copy(a))
 # a=sparse([7 0;0 5])

--- a/src/model.jl
+++ b/src/model.jl
@@ -32,10 +32,10 @@ The fields of the `struct` as related to the arrays of the above formulation as 
 * The first `qA[1,i] = qA[2,i]` matrices are considered as dense in the computation.
 """
 mutable struct MyModel
-    A::Matrix{Any}
-    AA::Vector{SparseArrays.SparseMatrixCSC{Float64}}
-    B::Vector{SparseArrays.SparseMatrixCSC{Float64}}
-    C::Vector{SparseArrays.SparseMatrixCSC{Float64}}
+    A::Matrix{SparseArrays.SparseMatrixCSC{Float64,Int}}
+    AA::Vector{SparseArrays.SparseMatrixCSC{Float64,Int}}
+    B::Vector{SparseArrays.SparseMatrixCSC{Float64,Int}}
+    C::Vector{SparseArrays.SparseMatrixCSC{Float64,Int}}
     nzA::Matrix{Int64}
     sigmaA::Matrix{Int64}
     qA::Matrix{Int64}
@@ -49,10 +49,10 @@ mutable struct MyModel
     nlmi::Int64
 
     function MyModel(
-        A::Matrix{Any},
-        AA::Vector{SparseArrays.SparseMatrixCSC{Float64}},
-        B::Vector{SparseArrays.SparseMatrixCSC{Float64}},
-        C::Vector{SparseArrays.SparseMatrixCSC{Float64}},
+        A::Matrix{SparseArrays.SparseMatrixCSC{Float64,Int}},
+        AA::Vector{SparseArrays.SparseMatrixCSC{Float64,Int}},
+        B::Vector{SparseArrays.SparseMatrixCSC{Float64,Int}},
+        C::Vector{SparseArrays.SparseMatrixCSC{Float64,Int}},
         nzA::Matrix{Int64},
         sigmaA::Matrix{Int64},
         qA::Matrix{Int64},
@@ -121,9 +121,9 @@ function _prepare_A(A, datarank, κ)
 
     nlmi = size(A, 1)
     n = size(A, 2) - 1
-    AA = SparseMatrixCSC{Float64}[]
-    B = SparseMatrixCSC{Float64}[]
-    C = SparseMatrixCSC{Float64}[]
+    AA = SparseMatrixCSC{Float64,Int}[]
+    B = SparseMatrixCSC{Float64,Int}[]
+    C = SparseMatrixCSC{Float64,Int}[]
     nzA = zeros(Int64,n,nlmi)
     sigmaA = zeros(Int64,n,nlmi)
     qA = zeros(Int64,2,nlmi)


### PR DESCRIPTION
Let's first merge https://github.com/kocvara/Loraine.jl/pull/25, I'll rebase this one after.
After applying this PR on top of https://github.com/kocvara/Loraine.jl/pull/25, I now get for the same benchmark the result:
```
BenchmarkTools.Trial: 54 samples with 1 evaluation per sample.
 Range (min … max):  76.739 ms … 136.074 ms  ┊ GC (min … max): 0.00% … 11.23%
 Time  (median):     91.938 ms               ┊ GC (median):    4.00%
 Time  (mean ± σ):   93.162 ms ±  10.474 ms  ┊ GC (mean ± σ):  4.36% ±  3.65%

     ▄  ▁      ▁   ▁█▁▁▁ ▄▁ ██  ▁        ▁                      
  ▆▁▁█▆▁█▆▁▁▁▆▆█▆▆▆█████▆██▆██▁▁█▆▁▁▁▆▁▁▁█▆▆▁▁▁▁▁▆▁▁▁▁▁▁▁▁▆▁▁▆ ▁
  76.7 ms         Histogram: frequency by time          118 ms <

 Memory estimate: 36.52 MiB, allocs estimate: 10206.
```
So a bit win in terms of number of allocations and a small +- 10% win in terms of time.
The reason is that `SparseMatrixCSC{Float64}` is not concrete if you don't specify `Int` so whenever you access an entry of the Vector, Julia don't know the type so it needs to do a runtime method dispatch which is slow. This is detailed here: https://docs.julialang.org/en/v1/manual/performance-tips/#Avoid-fields-with-abstract-type
Note that there is the excellent `@profview_allocs` in BenchmarkTools to track where allocations are coming from. You should run it twice and discard the first result to avoid seeing the allocations due to the compilation of `@profview_allocs` itself ;)
Another good approach is to add `@time begin ... end` inside your code to see if that part is going allocations. Note that `@time` itself allocates so if you have a `@time` inside another one, only what's reported by the inner one is relevant.
I'm planning to do a follow up PR that tries to chop down the last 10k allocs