### PR TITLE
Fix step_pred in sigma_update

### DIFF
--- a/src/predictor_corrector.jl
+++ b/src/predictor_corrector.jl
@@ -127,9 +127,9 @@ end
 
 function sigma_update(solver::MySolver{T}) where {T}
     step_pred = min(
-        minimum(solver.alpha; init = zero(T)),
+        minimum(solver.alpha; init = one(T)),
         solver.alpha_lin,
-        minimum(solver.beta; init = zero(T)),
+        minimum(solver.beta; init = one(T)),
         solver.beta_lin,
     )
     if (solver.mu > 1e-6)

--- a/src/predictor_corrector.jl
+++ b/src/predictor_corrector.jl
@@ -126,7 +126,12 @@ function predictor(solver::MySolver{T},halpha::Halpha) where {T}
 end
 
 function sigma_update(solver::MySolver{T}) where {T}
-    step_pred = min(min(minimum(solver.alpha), solver.alpha_lin), min(minimum(solver.beta), solver.beta_lin))
+    step_pred = min(
+        minimum(solver.alpha; init = zero(T)),
+        solver.alpha_lin,
+        minimum(solver.beta; init = zero(T)),
+        solver.beta_lin,
+    )
     if (solver.mu > 1e-6)
         if (step_pred < 1 / sqrt(3))
                 expon_used = 1.0


### PR DESCRIPTION
Found by the solver-tests in MOI: https://github.com/jump-dev/MathOptInterface.jl/actions/runs/30219991948/job/89840668915

You don't need `min(min, min)`, and you need an initial value if `.alpha` and `.beta` are empty.

Not sure if you want `zero(T)` or something like `typemax(T)`? 